### PR TITLE
Update accent to 0.4.7 (with Makefile!)

### DIFF
--- a/Formula/accent.rb
+++ b/Formula/accent.rb
@@ -1,12 +1,17 @@
 class Accent < Formula
   desc "Sync, merge and export with the Accent API. Just a fancy cUrl wrapper."
   homepage "https://github.com/mirego/accent-cli"
-  url "https://github.com/mirego/accent-cli/archive/0.3.0.tar.gz"
-  sha256 "c85375f57a90bc29f0b6ebbb6f03d74df1e5c0f4944b00982803de2283b6e433"
+  url "https://github.com/mirego/accent-cli/archive/0.4.7.tar.gz"
+  sha256 "a305e8c035ab7ebd00625f48766f17a4eb89bced20ea58af721adc78855896a4"
 
   head "https://github.com/mirego/accent-cli.git"
 
   def install
+    system "make", "build"
     bin.install "accent"
+  end
+
+  test do
+    system bin/"accent", "--version"
   end
 end


### PR DESCRIPTION
`accent-cli` is now built using `make build`.
